### PR TITLE
[BUG] Save correct fine error map in eval.py

### DIFF
--- a/eval/eval.py
+++ b/eval/eval.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
                 fine_err_map = torch.sum((fine_pred_rgb - gt_rgb) ** 2, dim=-1).numpy()
                 fine_err_map_colored = (colorize_np(fine_err_map, range=(0., 1.)) * 255).astype(np.uint8)
                 imageio.imwrite(os.path.join(out_scene_dir, '{}_err_map_fine.png'.format(file_id)),
-                                coarse_err_map_colored)
+                                fine_err_map_colored)
 
                 fine_pred_rgb = (255 * np.clip(fine_pred_rgb.numpy(), a_min=0, a_max=1.)).astype(np.uint8)
                 imageio.imwrite(os.path.join(out_scene_dir, '{}_pred_fine.png'.format(file_id)), fine_pred_rgb)


### PR DESCRIPTION
In eval/eval.py, the COARSE error map was saved by mistake for the
FINE error map. This PR correctly saves the fine error map instead.